### PR TITLE
enables hit return for search

### DIFF
--- a/client/src/components/Search/ResultsContainer.js
+++ b/client/src/components/Search/ResultsContainer.js
@@ -7,7 +7,7 @@ import { SaveBook, CreateRelationship } from './Action';
 const useStyles = makeStyles(theme => ({
     card: {
         margin: theme.spacing(2, 1),
-        padding: theme.spacing(2),
+        padding: theme.spacing(0.5),
         display: 'flex',
         justifyContent: 'space-between'
     }
@@ -43,7 +43,7 @@ const ResultsContainer = ({ book }) => {
                     {book.bookName}
                 </Typography>
                 <Typography className={classes.pos} color="textSecondary">
-                    {book.bookAuthor}
+                    {JSON.parse(book.bookAuthor).join(', ')}
                 </Typography>
                 <Typography variant="body2">{truncate(book.bookDesc, 280)}</Typography>
             </CardContent>

--- a/client/src/components/Search/SearchForm.js
+++ b/client/src/components/Search/SearchForm.js
@@ -59,6 +59,8 @@ const SearchForm = () => {
     };
 
     const handleSearch = async event => {
+        event.preventDefault();
+
         setUndetectedMessage('');
         setBooks([]);
         try {
@@ -80,45 +82,47 @@ const SearchForm = () => {
     return (
         <div>
             <Scanner handleDetected={handleDetected} />
-            <FormControl
-                fullWidth
-                className={classes.root}
-                variant="outlined"
-                color="secondary"
-                noValidate
-                autoComplete="off"
-                style={{ flexDirection: 'row', flexWrap: 'wrap' }}>
-                <InputLabel id="search-type">Search type</InputLabel>
-                <Select
-                    className={classes.largeForm}
-                    label="Search type"
-                    labelId="search-type"
-                    id="search-type"
-                    value={searchType}
-                    onChange={handleChange}>
-                    <MenuItem value="isbn">ISBN</MenuItem>
-                    <MenuItem value="author">Author name</MenuItem>
-                    <MenuItem value="title">Book title</MenuItem>
-                </Select>
+            <form onSubmit={handleSearch}>
+                <FormControl
+                    fullWidth
+                    className={classes.root}
+                    variant="outlined"
+                    color="secondary"
+                    noValidate
+                    autoComplete="off"
+                    style={{ flexDirection: 'row', flexWrap: 'wrap' }}>
+                    <InputLabel id="search-type">Search type</InputLabel>
+                    <Select
+                        className={classes.largeForm}
+                        label="Search type"
+                        labelId="search-type"
+                        id="search-type"
+                        value={searchType}
+                        onChange={handleChange}>
+                        <MenuItem value="isbn">ISBN</MenuItem>
+                        <MenuItem value="author">Author name</MenuItem>
+                        <MenuItem value="title">Book title</MenuItem>
+                    </Select>
 
-                {searchType !== '' && (
-                    <>
-                        <TextField
-                            fullWidth
-                            id="outlined-basic"
-                            label="Search"
-                            variant="outlined"
-                            color="secondary"
-                            onChange={e => setSearchTerm(e.target.value)}
-                            value={searchTerm}
-                            className={classes.largeForm}
-                        />
-                        <Button className={classes.largeForm} onClick={handleSearch}>
-                            Search
-                        </Button>
-                    </>
-                )}
-            </FormControl>
+                    {searchType !== '' && (
+                        <>
+                            <TextField
+                                fullWidth
+                                id="outlined-basic"
+                                label="Search"
+                                variant="outlined"
+                                color="secondary"
+                                onChange={e => setSearchTerm(e.target.value)}
+                                value={searchTerm}
+                                className={classes.largeForm}
+                            />
+                            <Button className={classes.largeForm} type="submit">
+                                Search
+                            </Button>
+                        </>
+                    )}
+                </FormControl>
+            </form>
 
             <Typography variant="body1">{undetectedMessage && undetectedMessage}</Typography>
 


### PR DESCRIPTION
# Description

Users can now hit return instead of clicking the search button.

## Type of change

Please delete options that are not relevant.

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
